### PR TITLE
Add root level id

### DIFF
--- a/catalog.bom
+++ b/catalog.bom
@@ -18,6 +18,7 @@
 #
 
 brooklyn.catalog:
+  id: salt-mysql-example
   name: Classic Models Database
   version: 0.1.0
   itemType: template


### PR DESCRIPTION
In order to be compatible with the catalog service spec it needs an `id` key at the root.